### PR TITLE
Removing no dev flag from poetry install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY pyproject.toml /code/
 
 RUN pip3 install poetry
 RUN poetry config virtualenvs.create false
-RUN poetry install --no-dev
+RUN poetry install


### PR DESCRIPTION
*What does this PR do?*
Installs development dependencies while build building new api containers.

*Jira ticket number?*
This is just a hot fix to improve local development

*Changes*

- Removing `--no dev` to make sure that we are installing development dependencies with Poetry

*Testing*

There isn't really any testing to be done.
