### PR TITLE
adding permission constants to utils

### DIFF
--- a/access_management/utils.py
+++ b/access_management/utils.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import Group
+from access_management.permission_constants import *
 from guardian.shortcuts import assign_perm
 
 PERMISSION_GROUP_SUFFIX = "_permission_group"


### PR DESCRIPTION
*What does this PR do?*

This fixes the failing user permissions test by giving the `generate_groups_and_permission` method access to the needed permission constants.

*Jira ticket number?*
N/A

*Changes*

- giving the `generate_groups_and_permission` method access to the needed permission constants in `utils.py`

*Testing*

- [ ] Step 1: try to create a new project through the admin interface
