### PR TITLE
handle logging level when testing for failed api calls

### DIFF
--- a/catalogs/tests.py
+++ b/catalogs/tests.py
@@ -3,6 +3,8 @@ from django.test import Client, TestCase
 from django.urls import reverse
 from rest_framework import status
 
+from testing_utils import prevent_request_warnings
+
 from .catalogio import CatalogTools as Tools
 from .models import Catalog
 
@@ -36,6 +38,7 @@ class CatalogModelTest(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @prevent_request_warnings
     def test_post_control_by_id(self):
         cid = self.cat.id
         response = client.post(

--- a/components/tests.py
+++ b/components/tests.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from catalogs.models import Catalog
+from testing_utils import prevent_request_warnings
 
 from .componentio import ComponentTools
 from .models import Component
@@ -227,6 +228,7 @@ class GetSingleComponentTest(TestCase):
         self.assertEqual(response.data, serializer.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @prevent_request_warnings
     def test_get_invalid_single_component(self):
         invalid_id = 0
         response = client.get(reverse("component-detail", kwargs={"pk": invalid_id}))
@@ -259,6 +261,7 @@ class CreateNewComponentTest(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    @prevent_request_warnings
     def test_create_invalid_component(self):
         self.invalid_payload = {
             "not_real": "this is not a valid field for a component and will fail create attempt"
@@ -290,6 +293,7 @@ class CreateNewComponentTest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     # required field tests
+    @prevent_request_warnings
     def test_title_field_is_required(self):
         self.invalid_payload_without_title = {
             "description": "Probably the coolest component you ever did see. It's magical.",
@@ -307,6 +311,7 @@ class CreateNewComponentTest(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    @prevent_request_warnings
     def test_catalog_field_is_required(self):
         self.invalid_payload_without_catalog = {
             "title": "Cool Component",
@@ -324,6 +329,7 @@ class CreateNewComponentTest(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    @prevent_request_warnings
     def test_controls_field_is_required(self):
         self.invalid_payload_without_controls = {
             "title": "Cool Component",
@@ -341,6 +347,7 @@ class CreateNewComponentTest(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    @prevent_request_warnings
     def test_type_field_is_required(self):
         self.invalid_payload_without_type = {
             "title": "Cool Component",
@@ -358,6 +365,7 @@ class CreateNewComponentTest(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    @prevent_request_warnings
     def test_component_json_field_is_required(self):
         self.invalid_payload_without_component_json = {
             "title": "Cool Component",

--- a/testing_utils.py
+++ b/testing_utils.py
@@ -1,0 +1,22 @@
+import logging
+
+
+def prevent_request_warnings(original_function):
+    """
+    If we need to test for 400s or 404s this decorator can prevent
+    the request class from throwing warnings.
+    """
+
+    def new_function(*args, **kwargs):
+        # raise logging level to ERROR
+        logger = logging.getLogger("django.request")
+        previous_logging_level = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
+
+        # trigger original function that would throw warning
+        original_function(*args, **kwargs)
+
+        # lower logging level back to previous
+        logger.setLevel(previous_logging_level)
+
+    return new_function

--- a/users/tests.py
+++ b/users/tests.py
@@ -4,6 +4,8 @@ from django.test import Client, TestCase
 from django.urls import reverse
 from rest_framework import status
 
+from testing_utils import prevent_request_warnings
+
 from .models import User
 from .serializers import UserSerializer
 
@@ -52,6 +54,7 @@ class GetSingleUserTest(TestCase):
         self.assertEqual(response.data, serializer.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @prevent_request_warnings
     def test_get_invalid_single_user(self):
         invalid_id = 0
         response = client.get(reverse("user-detail", kwargs={"pk": invalid_id}))
@@ -75,6 +78,7 @@ class CreateNewUserTest(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    @prevent_request_warnings
     def test_create_invalid_user(self):
         # note that username is required for valid post
         self.invalid_payload = {
@@ -115,6 +119,7 @@ class UpdateSingleUserTest(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @prevent_request_warnings
     def test_invalid_update_user(self):
         self.invalid_payload = {
             "username": "",


### PR DESCRIPTION
*What does this PR do?*
Handles logging level when testing for failed api calls so warnings don't unnecessarily show up in the terminal.

*Jira ticket number?*
N/A

*Changes*

- Added testing_utils file containing a decorator function that changes the logging level to error, then runs the desired function, then sets the logging back.
- Added the decorator function to specific tests that test for intentionally failed api calls- we don't want to see warnings for these since we know they are supposed to happen.


This should clear up the following warnings when running the test suite:
```
WARNING:django.request:Method Not Allowed: /api/catalogs/4/control/ac-1/
WARNING:django.request:Bad Request: /api/components/
WARNING:django.request:Bad Request: /api/components/
WARNING:django.request:Bad Request: /api/components/
WARNING:django.request:Bad Request: /api/components/
WARNING:django.request:Bad Request: /api/components/
WARNING:django.request:Bad Request: /api/components/
WARNING:django.request:Not Found: /api/components/0/
WARNING:django.request:Bad Request: /api/users/
WARNING:django.request:Not Found: /api/users/0/
WARNING:django.request:Bad Request: /api/users/8/
```
