### PR TITLE
Adding component_file to serializer.

### DIFF
--- a/components/serializers.py
+++ b/components/serializers.py
@@ -23,6 +23,7 @@ class ComponentListSerializer(serializers.ModelSerializer):
             "type",
             "catalog",
             "component_json",
+            "component_file",
             "controls_count",
         )
 


### PR DESCRIPTION
*What does this PR do?*
Fixes a bug when importing components via the API

*Jira ticket number?*
[ISPGBSS-1151](https://jiraent.cms.gov/browse/ISPGBSS-1151)

*Changes*

- Added component_file to serializer

*Testing*

- [ ] Using Postman make a POST call to http://localhost:8000/api/components with the following fields
- [ ] title, component_file (OSCAL file from library), and catalog
- [ ] You should get a 201 response
