### PR TITLE
new endpoint to return a list of public components not in a project

### DIFF
--- a/projects/urls.py
+++ b/projects/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from .views import (
     ProjectAddComponentView,
     ProjectComponentListSearchView,
+    ProjectComponentNotAddedListView,
     ProjectGetControlData,
     ProjectRemoveComponentView,
     ProjectsDetailView,
@@ -31,5 +32,10 @@ urlpatterns = [
         "<int:project_id>/search/",
         ProjectComponentListSearchView.as_view(),
         name="component-search",
+    ),
+    path(
+        "<int:project_id>/components-not-added/",
+        ProjectComponentNotAddedListView.as_view(),
+        name="components-not-in-project",
     ),
 ]

--- a/projects/views.py
+++ b/projects/views.py
@@ -159,3 +159,15 @@ class ProjectComponentListSearchView(APIView):
         response.append({"type_list": type_list})
 
         return Response(response, status=status.HTTP_200_OK)
+
+
+class ProjectComponentNotAddedListView(APIView):
+    def get(self, request, project_id, *args, **kwargs):
+        project_instance = get_object_or_404(Project, pk=project_id)
+        queryset = (
+            Component.objects.exclude(used_by_projects=project_instance)
+            .exclude(status=1)
+            .order_by("pk")
+        )
+        serializer = ComponentListBasicSerializer(queryset, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
*What does this PR do?*
new endpoint to return a list of public components not added into a project

*Jira ticket number?*
[ISPGBSS-1158](https://jiraent.cms.gov/browse/ISPGBSS-1158)

*Changes*

- new endpoint to return a list of public components not in a project

*Testing*

- After a project has been created and has components associated with it
- go to /projects/{projectId}/components-not-added/
- Confirm components returned are not in the project already
