### PR TITLE
updated api response format

### DIFF
--- a/projects/tests.py
+++ b/projects/tests.py
@@ -626,9 +626,9 @@ class ProjectComponentSearchViewTest(TestCase):
             "/api/projects/" + str(self.test_project.id) + "/search/", format="json"
         )
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(json.loads(resp.content)[2].get("total_item_count"), 3)
-        self.assertEqual(json.loads(resp.content)[3].get("type_list")[0][0], "policy")
-        self.assertEqual(json.loads(resp.content)[3].get("type_list")[1][0], "software")
+        self.assertEqual(json.loads(resp.content).get("total_item_count"), 3)
+        self.assertEqual(json.loads(resp.content).get("type_list")[0][0], "policy")
+        self.assertEqual(json.loads(resp.content).get("type_list")[1][0], "software")
 
     def test_search_term_ociso(self):
         resp = self.client.get(
@@ -637,9 +637,9 @@ class ProjectComponentSearchViewTest(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(
-            json.loads(resp.content)[1].get("components")[0].get("title"), "OCISO"
+            json.loads(resp.content).get("components")[0].get("title"), "OCISO"
         )
-        self.assertEqual(json.loads(resp.content)[2].get("total_item_count"), 1)
+        self.assertEqual(json.loads(resp.content).get("total_item_count"), 1)
 
     def test_search_filter_type_software(self):
         resp = self.client.get(
@@ -648,9 +648,9 @@ class ProjectComponentSearchViewTest(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(
-            json.loads(resp.content)[1].get("components")[0].get("type"), "software"
+            json.loads(resp.content).get("components")[0].get("type"), "software"
         )
-        self.assertEqual(json.loads(resp.content)[2].get("total_item_count"), 2)
+        self.assertEqual(json.loads(resp.content).get("total_item_count"), 2)
 
 
 class ProjectComponentNotAddedListViewTest(TestCase):

--- a/projects/views.py
+++ b/projects/views.py
@@ -152,11 +152,12 @@ class ProjectComponentListSearchView(APIView):
             project_instance.components.all().order_by().values_list("type").distinct()
         )
 
-        response = []
-        response.append({"project": project_serializer.data})
-        response.append({"components": serializer.data})
-        response.append({"total_item_count": paginator.count})
-        response.append({"type_list": type_list})
+        response = {
+            "project": project_serializer.data,
+            "components": serializer.data,
+            "total_item_count": paginator.count,
+            "type_list": type_list,
+        }
 
         return Response(response, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
*What does this PR do?*
Changed the response format to utilize a dictionary instead of list for project component search
*Jira ticket number?*
[ISPGBSS-1198](https://jiraent.cms.gov/browse/ISPGBSS-1198)

*Changes*

- Changed the response format to utilize a dictionary instead of list

*Testing*

- /api/projects/#/search/ should return the response in a dictionary format at the top level
