### PR TITLE
Bug/fix component types filter

### DIFF
--- a/components/filters.py
+++ b/components/filters.py
@@ -37,5 +37,5 @@ class ComponentPermissionsFilter(BaseFilterBackend):
 
         return (
                 get_objects_for_user(user, permission, queryset, accept_global_perms=False)
-                | queryset.filter(status=Component.Status.PUBLIC)
+                .union(queryset.filter(status=Component.Status.PUBLIC))
         )

--- a/components/filters.py
+++ b/components/filters.py
@@ -38,4 +38,5 @@ class ComponentPermissionsFilter(BaseFilterBackend):
         return (
                 get_objects_for_user(user, permission, queryset, accept_global_perms=False)
                 .union(queryset.filter(status=Component.Status.PUBLIC))
+                .order_by("pk")
         )

--- a/components/tests.py
+++ b/components/tests.py
@@ -502,8 +502,11 @@ class ComponentTypesViewTest(AuthenticatedAPITestCase):
     def test_get_types_list(self):
         resp = self.client.get("/api/components/types/", format="json")
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(json.loads(resp.content)[0][0], "policy")
-        self.assertEqual(json.loads(resp.content)[1][0], "software")
+
+        content = resp.json()
+        # Data structure in response is [["type1"], ["type2"], ..]
+        flattened = sorted(value for item in content for value in item)
+        self.assertEqual(flattened, ["policy", "software"])
 
     def test_types_without_superuser(self):
         # Create a non-super user with default permissions
@@ -530,7 +533,6 @@ class ComponentTypesViewTest(AuthenticatedAPITestCase):
         # Data structure in response is [["type1"], ["type2"], ..]
         flattened = sorted(value for item in content for value in item)
 
-        self.assertEqual(len(flattened), 2)
         self.assertEqual(flattened, ["policy", "software"])
 
 

--- a/components/tests.py
+++ b/components/tests.py
@@ -183,7 +183,7 @@ class GetAllComponentsTest(AuthenticatedAPITestCase):
     def test_get_all_components(self):
 
         response = self.client.get(reverse("component-list"))
-        components = Component.objects.all()
+        components = Component.objects.all().order_by("pk")
         serializer = ComponentListSerializer(components, many=True)
 
         expected_num_components = 2

--- a/components/tests.py
+++ b/components/tests.py
@@ -5,13 +5,15 @@ from django.core.files import File
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
+from rest_framework.authtoken.models import Token
 
 from catalogs.models import Catalog
 from testing_utils import AuthenticatedAPITestCase, prevent_request_warnings
 
-from .componentio import ComponentTools, EmptyComponent
-from .models import Component
-from .serializers import ComponentListSerializer, ComponentSerializer
+from components.componentio import ComponentTools, EmptyComponent
+from components.models import Component
+from components.serializers import ComponentListSerializer, ComponentSerializer
+from users.models import User
 
 TEST_COMPONENT_JSON_BLOB = {
     "component-definition": {
@@ -502,6 +504,34 @@ class ComponentTypesViewTest(AuthenticatedAPITestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(json.loads(resp.content)[0][0], "policy")
         self.assertEqual(json.loads(resp.content)[1][0], "software")
+
+    def test_types_without_superuser(self):
+        # Create a non-super user with default permissions
+        user = User.objects.create(username="TestUser", password="password")
+        token = Token.objects.create(user=user)
+        self.client.force_authenticate(user=user, token=token)
+
+        # Create a private component (result should not be available to types endpoint)
+        Component.objects.create(
+            title="Private component",
+            description="testing description",
+            catalog=self.test_catalog,
+            controls=["ac-2.1"],
+            search_terms=["cool", "magic", "software"],
+            type="crazy-type",
+            component_json=TEST_COMPONENT_JSON_BLOB,
+            status=Component.Status.SYSTEM,
+        )
+
+        response = self.client.get("/api/components/types/")
+        self.assertEqual(response.status_code, 200)
+
+        content = response.json()
+        # Data structure in response is [["type1"], ["type2"], ..]
+        flattened = sorted(value for item in content for value in item)
+
+        self.assertEqual(len(flattened), 2)
+        self.assertEqual(flattened, ["policy", "software"])
 
 
 class CreateEmptComponentTest(TestCase):

--- a/components/views.py
+++ b/components/views.py
@@ -3,7 +3,6 @@ from django_filters import rest_framework as filters
 from rest_framework import generics, status
 from rest_framework.response import Response
 
-from blueprintapi.filters import ObjectPermissionsFilter
 from components.filters import ComponentFilter, ComponentPermissionsFilter
 from components.models import Component
 from components.permissions import ComponentPermissions
@@ -59,7 +58,7 @@ class ComponentListSearchView(generics.ListAPIView):
 class ComponentTypeListView(generics.ListAPIView):
     queryset = Component.objects.order_by().values_list("type").distinct()
     permission_classes = [ComponentPermissions, ]
-    filter_backends = [ObjectPermissionsFilter, ]
+    filter_backends = [ComponentPermissionsFilter, ]
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())

--- a/components/views.py
+++ b/components/views.py
@@ -13,7 +13,7 @@ class ComponentListView(generics.ListCreateAPIView):
     """Use for read-write endpoints to represent a collection of model instances.
     Provides get and post method handlers.
     """
-    queryset = Component.objects.all().order_by("pk")
+    queryset = Component.objects.all()
     serializer_class = ComponentListSerializer
     permission_classes = [ComponentPermissions, ]
     filter_backends = [ComponentPermissionsFilter, ]


### PR DESCRIPTION
*What does this PR do?*
Fixes a bug in the component types view where the incorrect permissions filter was being used resulting in missing types in the response.

*Jira ticket number?*
[ISPGBSS-1219](https://jiraent.cms.gov/browse/ISPGBSS-1219)

*Changes*
- Update `ComponentTypeListView` to use the more specific `ComponentPermissionsFilter` class.
- Update `ComponentPermissionsFilter` QuerySet to use a `union` instead of the `|` operator

