### PR TITLE
Add private component id to project info

### DIFF
--- a/projects/serializers.py
+++ b/projects/serializers.py
@@ -66,10 +66,16 @@ class ProjectSerializer(serializers.ModelSerializer):
 
 class BasicViewProjectSerializer(serializers.ModelSerializer):
     """Project serializer for the case where only basic project info is needed."""
+    private_component = serializers.SerializerMethodField(read_only=True)
+
     class Meta:
         model = Project
-        fields = ("id", "title", "acronym", )
+        fields = ("id", "title", "acronym", "private_component", )
         read_only_fields = ("id", "title", "acronym", )
+
+    # noinspection PyMethodMayBeStatic
+    def get_private_component(self, obj: Project) -> int:
+        return obj.components.get(title=f"{obj.title} private").id
 
 
 class ProjectControlSerializer(serializers.ModelSerializer):

--- a/projects/tests.py
+++ b/projects/tests.py
@@ -447,11 +447,9 @@ class ProjectControlPage(AuthenticatedAPITestCase):
             catalog=test_catalog,
         )
 
-        test_project.components.set(
-            [
-                test_component,
-                test_component_2,
-            ]
+        test_project.components.add(
+            test_component,
+            test_component_2,
         )
 
         cls.test_project = test_project
@@ -788,9 +786,10 @@ class RetrieveUpdateProjectControlViewTestCase(AuthenticatedAPITestCase):
 
         content = response.json()
         project = content["project"]
-        expected = {'id': 1, 'title': 'Test project', 'acronym': 'TP', 'private_component': 1}
-
-        self.assertDictEqual(project, expected)
+        self.assertTrue(all(item in project for item in ("id", "title", "acronym", "private_component", )))
+        self.assertIsNotNone(project["private_component"])
+        self.assertEqual(project["title"], "Test project")
+        self.assertEqual(project["acronym"], "TP")
 
     def test_missing_control_returns_404(self):
         response = self.client.get(

--- a/projects/tests.py
+++ b/projects/tests.py
@@ -780,6 +780,18 @@ class RetrieveUpdateProjectControlViewTestCase(AuthenticatedAPITestCase):
             with self.subTest(field=field):
                 self.assertEqual(control[field], value)
 
+    def test_get_project_control_project_info(self):
+        response = self.client.get(
+            reverse("project-get-control", kwargs={"project_id": self.project.id, "control_id": "ac-1"})
+        )
+        self.assertEqual(response.status_code, 200)
+
+        content = response.json()
+        project = content["project"]
+        expected = {'id': 1, 'title': 'Test project', 'acronym': 'TP', 'private_component': 1}
+
+        self.assertDictEqual(project, expected)
+
     def test_missing_control_returns_404(self):
         response = self.client.get(
             reverse("project-get-control", kwargs={"project_id": self.project.id, "control_id": "not-a-control"})


### PR DESCRIPTION
*What does this PR do?*
This PR adds a project's private component id to the basic project info returned in individual project control page responses.

*Jira ticket number?*
Indirectly supports: https://jiraent.cms.gov/browse/ISPGBSS-1017

*Changes*
- Added `private_component` field to `BasicViewProjectSerializer`
- Added tests
