### PR TITLE
Check token expiration before responding

### DIFF
--- a/blueprintapi/tests.py
+++ b/blueprintapi/tests.py
@@ -4,6 +4,7 @@ import tempfile
 import time
 
 from django.test import SimpleTestCase
+from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
 
@@ -32,8 +33,36 @@ class UnauthenticatedAPITestCase(APITestCase):
             response = self.client.get('/api/catalogs/')
 
             self.assertEqual(response.status_code, 401)
+            # noinspection PyTypeChecker
             with self.assertRaises(Token.DoesNotExist):
                 Token.objects.get(user=user)
+
+    def test_expired_token_is_refreshed_on_successful_auth(self):
+        login = json.dumps({"username": "test", "password": "SuperSecretPassword"})
+
+        # Need to create the test user through the client
+        create_user = self.client.post("/api/users/", data=login, content_type="application/json")
+        self.assertEqual(create_user.status_code, status.HTTP_201_CREATED)
+
+        initial = self.client.post("/api-token-auth/", data=login, content_type="application/json")
+        self.assertEqual(initial.status_code, status.HTTP_200_OK)
+
+        initial_token = initial.json()["token"]
+
+        time.sleep(1)
+
+        with self.settings(AUTH_TOKEN_TTL=1 / 60**2):  # 1s
+            response = self.client.post("/api-token-auth/", data=login, content_type="application/json")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        content = response.json()
+
+        # The expired token will have been refreshed.
+        self.assertNotEqual(initial_token, content["token"])
+
+        # noinspection PyTypeChecker
+        with self.assertRaises(Token.DoesNotExist):
+            Token.objects.get(key=initial_token)
 
 
 COMPONENT_DATA = {

--- a/blueprintapi/views.py
+++ b/blueprintapi/views.py
@@ -43,7 +43,7 @@ class UserObtainTokenView(ObtainAuthToken):
             try:
                 auth.authenticate_credentials(token.key)
             except AuthenticationFailed:
-                new_token, _ = Token.objects.create(user=user)
+                new_token = Token.objects.create(user=user)
                 response_data["token"] = new_token.key
 
             return Response(response_data)

--- a/blueprintapi/views.py
+++ b/blueprintapi/views.py
@@ -2,8 +2,11 @@ from django.db import OperationalError, connection
 from rest_framework.authtoken.models import Token
 from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.decorators import api_view, permission_classes
+from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
+
+from blueprintapi.authentication import ExpiringTokenAuthentication
 
 
 @api_view(["GET"])
@@ -29,10 +32,20 @@ class UserObtainTokenView(ObtainAuthToken):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         user = serializer.validated_data['user']
-        token, _ = Token.objects.get_or_create(user=user)
-        return Response(
-            {
+        token, created = Token.objects.get_or_create(user=user)
+        response_data = {
                 'token': token.key,
                 'user': {'username': user.username, 'full_name': user.get_full_name(), 'email': user.email},
             }
-        )
+
+        if not created:
+            auth = ExpiringTokenAuthentication()
+            try:
+                auth.authenticate_credentials(token.key)
+            except AuthenticationFailed:
+                new_token, _ = Token.objects.create(user=user)
+                response_data["token"] = new_token.key
+
+            return Response(response_data)
+
+        return Response(response_data)


### PR DESCRIPTION
*What does this PR do?*
This PR updates the `/api-token-auth/` endpoint to refresh the token if it's expired rather than sending back an expired token upon successful authentication.

*Jira ticket number?*


*Changes*
- Update the `UserObtainTokenView` to check the token if it already exists.

*Testing*

- [x] Modify the `AUTH_TOKEN_TTL` value to be short (a second or two)
- [x] Create a new user
- [x] Wait until the token has expired
- [x] Log in as the new user
- [x] Make a valid request as the new user (should no longer immediately redirect to login again).
