### PR TITLE
Use updated poetry version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,11 @@ ENV PYTHONFAULTHANDLER=1 \
     PYTHONHASHSEED=random \
     PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
-    PIP_DEFAULT_TIMEOUT=100 \
-    POETRY_VERSION=1.1.13
+    PIP_DEFAULT_TIMEOUT=100
 
 WORKDIR /usr/local
 
-RUN pip install pydantic
-
-RUN pip install "poetry==$POETRY_VERSION"
+RUN pip install --upgrade pip && pip install poetry
 
 COPY poetry.lock pyproject.toml /usr/local/
 


### PR DESCRIPTION
*What does this PR do?*
This PR updates the Dockerfie used for local development to use updated versions of poetry. This resolves an issue where poetry was erroneously removing a dependency requirement.

*Changes*
- Remove older poetry version
- Upgrade pip before install
