### PR TITLE
Fix controls ordering

### DIFF
--- a/catalogs/catalogio.py
+++ b/catalogs/catalogio.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 logger = logging.getLogger("catalogs.catalogio")
 
@@ -88,8 +88,15 @@ class CatalogTools:
         return controls
 
     def get_control_ids(self) -> List:
+        def _sort(control_id_: str) -> Tuple[str, float]:
+            parts = control_id_.split("-")
+            sub = float(parts.pop(-1))
+            id_ = "-".join(parts)
+
+            return id_, sub
+
         search_collection = self.get_controls()
-        return sorted(item.get("id") for item in search_collection)
+        return sorted((item.get("id") for item in search_collection), key=_sort)
 
     def get_controls_all(self) -> List:
         controls: List[dict] = []

--- a/projects/tests.py
+++ b/projects/tests.py
@@ -774,6 +774,9 @@ class RetrieveUpdateProjectControlViewTestCase(AuthenticatedAPITestCase):
             "title": "Policy and Procedures"
         }
 
+        with self.subTest(msg="Test next control"):
+            self.assertEqual(content["catalog_data"]["next_id"], "ac-2")
+
         for field, value in expected.items():
             with self.subTest(field=field):
                 self.assertEqual(control[field], value)

--- a/projects/views.py
+++ b/projects/views.py
@@ -169,7 +169,7 @@ class ProjectGetControlList(generics.ListAPIView):
         queryset = get_objects_for_user(user, "projects.view_project", Project.objects.all(), accept_global_perms=False)
         project = get_object_or_404(queryset, pk=self.kwargs.get("project_id"))
 
-        return ProjectControl.objects.filter(project=project)
+        return ProjectControl.objects.filter(project=project).order_by("control_id")
 
 
 class RetrieveUpdateProjectControlView(generics.RetrieveUpdateAPIView):


### PR DESCRIPTION
*What does this PR do?*
Fix sorting in identifying "next" control, and fix controls view queryset to include an order by.

*Jira ticket number?*
[ISPGBSS-1261](https://jiraent.cms.gov/browse/ISPGBSS-1261)

*Changes*
- Order controls in `catalogio` by compound key to correctly order by id
- Order queryset for `ProjectGetControlList`
